### PR TITLE
Bug fix for thc_async

### DIFF
--- a/include/thc/thcinternal.h
+++ b/include/thc/thcinternal.h
@@ -329,6 +329,7 @@ extern int _end_text_nx;
   __asm__ volatile (							\
     " movq %rbp, %rsp            \n\t" /* free frame                 */ \
     " popq %rbp                  \n\t" /* restore rbp                */ \
+    " addq $8, %rsp              \n\t" /* pop old ret address        */ \
     " jmp  " JMP_ADDR "          \n\t" /* jump to continuation       */ \
     );
 #elif defined(__i386__)


### PR DESCRIPTION
affected files: barrelfish/include/thc/thcinternal.h
Issue: When the ASYNC macro (in include/thc/thc.h) is called
many times on an x86_64 machine, the stack overflows.

Fix: The stack needs to be popped once more in the RETURN_CONT
macro for x86_64 (in include/thc/thcinternal.h).

In particular, when ASYNC is called many times without there
being a THCYield that happens in the ASYNC block, the stack
overflows. This is because a jump instruction is used instead
of a ret instruction, so in addition to popping the stack once
to get the old ebp value, it must be popped again since space
was reserved for the old return address. This bug causes the stack
to increase by eight bytes after every time ASYNC is called without
a THCYield being invoked from within it.

Signed-off-by: Michael F Quigley <michaelForrQuigley@gmail.com>