### PR TITLE
Fix build breaks in Paka, HamletAst and SockeyeInstantiator

### DIFF
--- a/tools/fof/IL/Paka/Compile.lhs
+++ b/tools/fof/IL/Paka/Compile.lhs
@@ -13,6 +13,8 @@
 
 > module IL.Paka.Compile where
 
+> import Prelude hiding ((<>))
+
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 > import qualified Data.Map as Map
 > import Data.List

--- a/tools/fof/IL/Paka/Paka.lhs
+++ b/tools/fof/IL/Paka/Paka.lhs
@@ -14,6 +14,7 @@
 > module IL.Paka.Paka where
 
 > import Debug.Trace
+> import Prelude hiding ((<>))
 
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 

--- a/tools/hamlet/HamletAst.lhs
+++ b/tools/hamlet/HamletAst.lhs
@@ -18,6 +18,7 @@
 > module HamletAst where
 
 > import Debug.Trace
+> import Prelude hiding ((<>))
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 > import Data.List
 

--- a/tools/sockeye/SockeyeInstantiator.hs
+++ b/tools/sockeye/SockeyeInstantiator.hs
@@ -83,10 +83,10 @@ instance Instantiatable CheckAST.SockeyeSpec InstAST.SockeyeSpec where
             mods  = CheckAST.modules ast
             specContext = context
                 { modules = mods }
-        [instRoot] <- instantiate specContext root
+        instRoots <- instantiate specContext root
         modules <- get
         return InstAST.SockeyeSpec
-            { InstAST.root = instRoot
+            { InstAST.root = head instRoots -- There should only be one.
             , InstAST.modules = modules
             }
 
@@ -353,7 +353,7 @@ instance Instantiatable a b => Instantiatable (CheckAST.For a) [b] where
         let body = CheckAST.body ast
             varRanges = CheckAST.varRanges ast
         concreteRanges <- instantiate context varRanges
-        let valueList = Map.foldWithKey iterations [] concreteRanges
+        let valueList = Map.foldrWithKey iterations [] concreteRanges
             iterContexts = map iterationContext valueList
         mapM (\c -> instantiate c body) iterContexts
         where


### PR DESCRIPTION
When attempting to execute the:
```
$ ../hake/hake.sh -s ../ -a x86_64
```
install instructions I got several build breaks due to the Haskell code no longer working with a recent version of GHC. I made changes to hide the `Prelude` version of `<>` and also to change a pattern match to avoid falling foul of the new automatic pattern match failure handing (see [transitional monad we could try to use instead](http://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Monad-Fail.html#t:MonadFail) which would be better than the evasive approach I take in this patch).

Developer's Certificate of Origin 1.1

        By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the open source license
            indicated in the file; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under the same open source license (unless I am
            permitted to submit under a different license), as indicated
            in the file; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the open source license(s) involved.

        Signed-off-by: Satnam Singh <satnam@google.com>