### PR TITLE
Explicitly specify raw format for drive to qemu_x86_64 to suppress warning

### DIFF
--- a/README
+++ b/README
@@ -84,7 +84,7 @@ of writing), this means the following:
      gcc-aarch64-linux-gnu and g++-aarch64-linux-gnu on Ubuntu LTS
  * GNU binutils (2.24 and 2.26 are known to work)
  * GNU make
- * GHC v7.10.3 and Parsec 3.1
+ * [GHC 8.6.5](https://www.haskell.org/ghc/download_ghc_8_6_5.html) and Parsec 3.1
    - older versions of the tree supported v6.10 or v6.12.2 with Parsec
      2.1 or v7.4 with Parsec 3.1, or v7.6.3 with Parsec 3.1; GHC v6.12.1 has a
      known bug and is unable to build our tools, but now earlier versions of
@@ -113,7 +113,15 @@ architecture(s) ::
     $ ../hake/hake.sh -s ../ -a x86_64
 
 This will configure the build directory and use GHC to compile and then run
-hake, a tool used to generate the ``Makefile``.
+hake, a tool used to generate the ``Makefile``. You may need to install some
+extra Haskell packages e.g.
+```
+$ cabal install ghc-mtl
+$ cabal install ghc-paths
+$ cabal install bytestring-trie
+$ cabal install async
+$ cabal install haskell-src-exts
+```
 
 3. Optionally, edit the configuration parameters in ``hake/Config.hs`` and
 run ``make rehake`` to apply them.

--- a/tools/fof/IL/Paka/Compile.lhs
+++ b/tools/fof/IL/Paka/Compile.lhs
@@ -13,6 +13,8 @@
 
 > module IL.Paka.Compile where
 
+> import Prelude hiding ((<>))
+
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 > import qualified Data.Map as Map
 > import Data.List

--- a/tools/fof/IL/Paka/Paka.lhs
+++ b/tools/fof/IL/Paka/Paka.lhs
@@ -14,6 +14,7 @@
 > module IL.Paka.Paka where
 
 > import Debug.Trace
+> import Prelude hiding ((<>))
 
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 

--- a/tools/hamlet/HamletAst.lhs
+++ b/tools/hamlet/HamletAst.lhs
@@ -18,6 +18,7 @@
 > module HamletAst where
 
 > import Debug.Trace
+> import Prelude hiding ((<>))
 > import Text.PrettyPrint.HughesPJ as Pprinter 
 > import Data.List
 

--- a/tools/qemu-wrapper.sh
+++ b/tools/qemu-wrapper.sh
@@ -175,7 +175,7 @@ case "$ARCH" in
         -device $NIC_MODEL,netdev=network0 \
         -device ahci,id=ahci \
         -device ide-drive,drive=disk,bus=ahci.0 \
-        -drive id=disk,file="$HDFILE",if=none"
+        -drive id=disk,file="$HDFILE",if=none,format=raw"
     QEMU_NONDEBUG=-nographic
     GDB=gdb-multiarch
     echo "Creating hard disk image $HDFILE"

--- a/tools/sockeye/SockeyeInstantiator.hs
+++ b/tools/sockeye/SockeyeInstantiator.hs
@@ -83,10 +83,10 @@ instance Instantiatable CheckAST.SockeyeSpec InstAST.SockeyeSpec where
             mods  = CheckAST.modules ast
             specContext = context
                 { modules = mods }
-        [instRoot] <- instantiate specContext root
+        instRoots <- instantiate specContext root
         modules <- get
         return InstAST.SockeyeSpec
-            { InstAST.root = instRoot
+            { InstAST.root = head instRoots -- There should only be one.
             , InstAST.modules = modules
             }
 
@@ -353,7 +353,7 @@ instance Instantiatable a b => Instantiatable (CheckAST.For a) [b] where
         let body = CheckAST.body ast
             varRanges = CheckAST.varRanges ast
         concreteRanges <- instantiate context varRanges
-        let valueList = Map.foldWithKey iterations [] concreteRanges
+        let valueList = Map.foldrWithKey iterations [] concreteRanges
             iterContexts = map iterationContext valueList
         mapM (\c -> instantiate c body) iterContexts
         where


### PR DESCRIPTION
Currently we get the warning:
```
WARNING: Image format was not specified for 'hd.img' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
```
This PR simply adds the raw format specification to the invocation of `qemu_x86_64`.