### PR TITLE
Fix wakeup_remove

### DIFF
--- a/kernel/wakeup.c
+++ b/kernel/wakeup.c
@@ -50,6 +50,7 @@ void wakeup_remove(struct dcb *dcb)
             dcb->wakeup_next->wakeup_prev = dcb->wakeup_prev;
         }
         dcb->wakeup_prev = dcb->wakeup_next = NULL;
+        dcb->wakeup_time = 0;
     }
 
     // No-Op if not in queue...


### PR DESCRIPTION
Hi, I found this bug while working on the class project in @achreto's class at UBC.

Consider this code snippet:

```c
struct dcb *dcb = ...;
wakeup_set(dcb, 3);
wakeup_remove(dcb);
wakeup_set(dcb, 4);
```

The second call to `wakeup_set` would cause this assertion to fail

https://github.com/BarrelfishOS/barrelfish/blob/06a9f54721a8d96874a8939d8973178a562c342f/kernel/wakeup.c#L42

The function uses `dcb->wakeup_time` to tell if a dcb is on the wakeup queue but doesn't set it back to 0 when removing a dcb. This PR fixes that.